### PR TITLE
Tighten up hash spacing

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -55,7 +55,7 @@ values = (1..10).to_a.map { |x|
 * Use heredocs for multi-line strings.
 * Prefer `protected` over `private` for non-public `attr_reader`s, `attr_writer`s,
   and `attr_accessor`s.
-* When nesting hashes, avoid spacing between the braces and key/value pairs. `{a: {b: 1}}`, not `{ a: { b: 1 } }`.
+* Avoid spaces between braces and key value pairs when nesting hashes.  `{a: {b: 1}}`, not `{ a: { b: 1 } }`
 
 [trailing comma example]: /style/samples/ruby.rb#L49
 [required kwargs]: /style/samples/ruby.rb#L16

--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -55,6 +55,7 @@ values = (1..10).to_a.map { |x|
 * Use heredocs for multi-line strings.
 * Prefer `protected` over `private` for non-public `attr_reader`s, `attr_writer`s,
   and `attr_accessor`s.
+* When nesting hashes, avoid spacing between the braces and key/value pairs. `{a: {b: 1}}`, not `{ a: { b: 1 } }`.
 
 [trailing comma example]: /style/samples/ruby.rb#L49
 [required kwargs]: /style/samples/ruby.rb#L16


### PR DESCRIPTION
Rubocop wants spacing next to braces defining hashes. I think they look better without:

`{a: {b: 1}}`, not `{ a: { b: 1 } }` or `{a: { b: 1 }}`

What do y'alls think.